### PR TITLE
✨ Add a CLI option to skip source maps generation

### DIFF
--- a/cli/cmds/build.js
+++ b/cli/cmds/build.js
@@ -3,15 +3,21 @@ const Bundler = require("parcel-bundler");
 const path = require("path");
 const jsonminify = require("jsonminify");
 
-exports.command = "build [input] [output]";
+exports.command = "build [--no-source-maps] [input] [output]";
 exports.desc = "Build the source files for production use";
-exports.builder = {
-  cacheDir: {
-    default: '.cache'
-  }
+exports.builder = yargs => {
+  yargs.option('source-maps', {
+    boolean: true,
+    default: true,
+    describe: 'Skip source maps generation'
+  });
+  yargs.option('cache-dir', {
+    default: '.cache',
+  });
+  return yargs;
 };
 exports.handler = async function(argv) {
-  let { input, output, cacheDir } = argv;
+  let { input, output, cacheDir, sourceMaps } = argv;
   input = input || "src";
   output = output || "dist";
 
@@ -23,6 +29,7 @@ exports.handler = async function(argv) {
     minify: true,
     global: "__DirectusExtension__",
     cacheDir,
+    sourceMaps,
     publicUrl: './'
   });
 

--- a/cli/cmds/watch.js
+++ b/cli/cmds/watch.js
@@ -3,13 +3,19 @@ const Bundler = require("parcel-bundler");
 const path = require("path");
 const jsonminify = require("jsonminify");
 
-exports.command = "watch [input|--input] [output|--output]";
+exports.command = "watch [--no-source-maps] [input|--input] [output|--output]";
 
 exports.desc = "Watch the source files for changes and rebuild";
-exports.builder = {
-  cacheDir: {
-    default: '.cache'
-  }
+exports.builder = yargs => {
+  yargs.option('source-maps', {
+    boolean: true,
+    default: true,
+    describe: 'Skip source maps generation'
+  });
+  yargs.option('cache-dir', {
+    default: '.cache',
+  });
+  return yargs;
 };
 exports.handler = async function(argv) {
   let { input, output, cacheDir } = argv;
@@ -24,6 +30,7 @@ exports.handler = async function(argv) {
     minify: false,
     global: "__DirectusExtension__",
     cacheDir,
+    sourceMaps,
     publicUrl: './'
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@directus/extension-toolkit",
-  "version": "0.3.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@directus/extension-toolkit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "[WIP] Toolkit to help you build your own custom extensions!",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Fixes #19.
From an extension directory initialized using the direcuts-extensions command, one can invoke `npm run build -- --no-source-maps` to build without source maps.