### PR TITLE
Add example for translations in meta.json

### DIFF
--- a/cli/templates/meta.json
+++ b/cli/templates/meta.json
@@ -3,5 +3,21 @@
   "version": "1.0.0",
   "icon": "person",
   "types": ["string"],
-  "options": {}
+  "options": {
+    "custom-field": {
+      "name": "$t:field_name",
+      "default": "$t:field_default_value",
+    }
+  },
+  // translations are optional
+  "translation": {
+    "en-US": {
+      "field_name": "This is an additional field",
+      "field_default_value": "This is the additional field value"
+    },
+    "de-DE": {
+      "field_name": "Das ist ein zusätzliches Feld",
+      "field_default_value": "Das ist das zusätzliches Feldwert"
+    }
+  }
 }


### PR DESCRIPTION
Hi,

following the help received on Slack I'd like to slightly augment the base template with a suggestion on how to add a custom field and translate it, in case this might coime handy to someone else.

Let me know is this sounds good.

Cheers,